### PR TITLE
Just a minor spelling correction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ background I've assumed.
 
 
 ## Additional Resources
-* [Mike Stay's Tholang Tutorial](https://developer.rchain.coop/tutorial/)
+* [Mike Stay's Rholang Tutorial](https://developer.rchain.coop/tutorial/)
 * [The Core team's tutorial](https://github.com/rchain/rchain/blob/master/docs/rholang/rholangtut.md)
 * I hold office hours in https://zoom.us/j/6853551826 Thursday 7:00AM Seattle time
 * Contact me through [my website](https://joshyorndorff.com/contact).


### PR DESCRIPTION
Changed `Mike's Tholang Tutorial` into `Mike's Rholang Tutorial`